### PR TITLE
Bump pyopenssl version

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,7 +1,7 @@
 name: "python3-smpp-twisted3"
 arch: "amd64"
 platform: "linux"
-version: "v0.7"
+version: "v0.8"
 section: "default"
 priority: "extra"
 maintainer: "Jookies LTD <jasmin@jookies.net>"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Twisted~=22.1.0
-pyOpenSSL~=19.1.0
+pyOpenSSL~=22.0.0
 # cant install from other projects
 # smpp.pdu @ git+https://github.com/DomAmato/smpp.pdu.git@master
-smpp.pdu3~=0.4
+smpp.pdu3~=0.6

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name="smpp.twisted3",
-    version="0.7",
+    version="0.8",
     author="Roger Hoover",
     author_email="roger.hoover@gmail.com",
     description="SMPP 3.4 client built on Twisted / Python3",


### PR DESCRIPTION
In an attempt to add functionality(support TLS AMQP connections) into [jasmin](https://github.com/jookies/jasmin) project, I needed to bump pyopenssl version.